### PR TITLE
Fix Styling Issue on Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,9 @@ RUN apk add --no-cache tini
 WORKDIR /usr/src/app
 
 # Copy only necessary files from building stage 
-# COPY --from=builder /usr/src/app/package*.json ./
-# COPY --from=builder /usr/src/app/.next ./.next
-# COPY --from=builder /usr/src/app/public ./public
-# COPY --from=builder /usr/src/app/node_modules ./node_modules
-# COPY --from=builder /usr/src/app/app/data ./app/data
-COPY --from=builder /usr/src/app/.next/standalone ./
-COPY --from=builder /usr/src/app/.next/static ./.next/static
+COPY --from=builder /usr/src/app/package*.json ./
+COPY --from=builder /usr/src/app/node_modules ./node_modules
+COPY --from=builder /usr/src/app/.next ./.next
 COPY --from=builder /usr/src/app/public ./public
 
 # Ensure Next.js listens on all interfaces
@@ -44,5 +40,4 @@ EXPOSE 3000
 ENTRYPOINT ["tini", "--"]
 
 # run command 
-# CMD ["npm", "run", "start", "--", "--hostname", "0.0.0.0", "--port", "3000"]
-CMD ["node", "server.js"]
+CMD ["npm", "run", "start", "--", "--hostname", "0.0.0.0", "--port", "3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apk add --no-cache tini
 WORKDIR /usr/src/app
 
 # Copy only necessary files from building stage 
+COPY --from=builder /usr/src/app/app/data ./app/data
 COPY --from=builder /usr/src/app/package*.json ./
 COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/.next ./.next

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,14 @@
-@tailwind base;
+/* @tailwind base;
+@tailwind components;
+@tailwind utilities; */
+@layer tailwind {
+    @tailwind base;
+}
 @tailwind components;
 @tailwind utilities;
+
+/* @import mantine */
+@import "@mantine/core/styles.css";
 
 :root {
   --foreground-rgb: 0, 0, 0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -6,10 +6,8 @@
   --foreground-rgb: 0, 0, 0;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #1a1414
-  }
+:root[data-mantine-color-scheme="dark"] {
+    --mantine-color-body: #1a1414 !important;
 }
 
 /* global style */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import { Poppins, Roboto } from "next/font/google";
 
 import { Providers } from "./provider";
 
-import "@mantine/core/styles.css";
 import "./globals.css";
 
 const roboto = Roboto({

--- a/app/provider.tsx
+++ b/app/provider.tsx
@@ -1,8 +1,14 @@
 "use client";
 
-import { MantineProvider } from "@mantine/core";
+import {
+    MantineProvider
+} from "@mantine/core";
 import { ReactNode } from "react";
 
 export function Providers({ children }: { children: ReactNode }) {
-    return <MantineProvider>{children}</MantineProvider>;
+    return (
+        <MantineProvider 
+            defaultColorScheme="dark"
+        >{children}</MantineProvider>
+    )
 }


### PR DESCRIPTION
## Description
There was an issue with mantine default css overriding tailwind css on npm build. Resolved this issue by moving the call on `@mantine/core/styles.css` to `global.css`. 

## Changes
- Fix mantine default css overriding issue.
- Added docker configuration to copy over required json file ( fix #27 )